### PR TITLE
remove-filters

### DIFF
--- a/logstash-ng/logstash.conf
+++ b/logstash-ng/logstash.conf
@@ -19,8 +19,14 @@ filter {
     if [source] =~ /^\/var\/lib\/mesos\/slave\/slaves\/.*$/ {
        dissect {
           mapping => {
-             "source" => "/var/lib/mesos/slave/slaves/%{node}/frameworks/%{service}/executors/%{app}.%{+app}.%{taskid}/%{}"
+             "source" => "/var/lib/mesos/slave/slaves/%{node}/frameworks/%{service}/executors/%{executor}/%{}"
           }
+       }
+       grok {
+          match => {
+             "executor" => "^(%{GREEDYDATA:app}\.%{GREEDYDATA:taskid})?(%{GREEDYDATA:app}-%{GREEDYDATA:taskid})?$"
+          }
+          remove_field => ["executor"]
        }
     }
     if [namespace] == "com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker" {
@@ -36,11 +42,11 @@ filter {
     }
     # We want to do this as the whole point is to have searchable messages, however the performance hit is pretty hard due to many app
     # logs containing the entire event some of which are biggggg.
-    #if [msg] {
-    #   mutate {
-    #      rename => {"msg" => "message" }
-    #   }
-    #}
+    if [msg] {
+       mutate {
+          rename => {"msg" => "message" }
+       }
+    }
     if [source] == "/var/log/mesos/dcos.log" {
         grok {
             match => {

--- a/logstash-ng/logstash.conf
+++ b/logstash-ng/logstash.conf
@@ -12,6 +12,10 @@ filter {
           }
        }
     }
+    truncate {
+        fields => "message"
+        length_bytes => 1048576
+    }
     if [source] =~ /^\/var\/lib\/mesos\/slave\/slaves\/.*$/ {
        dissect {
           mapping => {

--- a/logstash-ng/logstash.conf
+++ b/logstash-ng/logstash.conf
@@ -19,6 +19,64 @@ filter {
           }
        }
     }
+    if [namespace] == "com.amazonaws.services.kinesis.clientlibrary.lib.worker.Worker" {
+        if [msg] == "Sleeping ..." {
+           drop { }
+        }
+        if [msg] == "No activities assigned" {
+            drop {}
+        }
+        if [msg] =~ /^Current stream shard assignments:.*$/ {
+            drop {}
+        }
+    }
+    # We want to do this as the whole point is to have searchable messages, however the performance hit is pretty hard due to many app
+    # logs containing the entire event some of which are biggggg.
+    #if [msg] {
+    #   mutate {
+    #      rename => {"msg" => "message" }
+    #   }
+    #}
+    if [source] == "/var/log/mesos/dcos.log" {
+        grok {
+            match => {
+                "message" => "^%{MONTH} %{MONTHDAY} %{TIME} %{HOSTNAME} %{GREEDYDATA:dcos.app}\[%{POSINT:pid}\]: ((?<log_severity>[EFIW])%{MONTHNUM}%{MONTHDAY}\s+%{TIME}\s+%{BASE10NUM:thread_id}\s+%{NOTSPACE:file}\:%{BASE10NUM:line}\]\s+)?%{GREEDYDATA:log_data}$"
+            }
+        }
+        if [log_data] =~ /HTTP GET for \/slave.*with User-Agent='Mesos-State.*$/ {
+            drop {}
+        }
+        if [log_data] {
+            mutate {
+               rename => {"log_data" => "message"}
+            }
+        }
+        if [log_severity] == "E" {
+            mutate {
+               replace  => { "log_severity" => "error" }
+            }
+        }
+        if [log_severity] == "W" {
+            mutate {
+               replace  => { "log_severity" => "warning" }
+            }
+        }
+        if [log_severity] == "I" {
+            mutate {
+               replace  => { "log_severity" => "info" }
+            }
+        }
+        if [log_severity] == "F" {
+            mutate {
+               replace  => { "log_severity" => "fatal" }
+            }
+        }
+        if [log_severity] {
+            mutate {
+                rename => { "log_severity" => "level" }
+            }
+        }
+    }
 }
 
 output {

--- a/logstash-ng/logstash.conf
+++ b/logstash-ng/logstash.conf
@@ -5,26 +5,6 @@ input{
 }
 
 filter {
-    truncate {
-             fields => "message"
-             length_bytes => 1048576
-             add_tag => ["truncated"]
-    }
-    json {
-        source => "message"
-        tag_on_failure => ["_messageparsefailure"]
-        skip_on_invalid_json => true
-    }
-    json {
-        source => "MESSAGE"
-        tag_on_failure => ["_MESSAGEjsonparsefailure"]
-        skip_on_invalid_json => true
-    }
-    json {
-        source => "msg"
-        tag_on_failure => ["_msgparsefailure"]
-        skip_on_invalid_json => true
-    }
     if [logtype] == "metric" {
        mutate {
           replace => {


### PR DESCRIPTION
Remove JSON filters as filebeat and metricbeat do any required decoding.
Add DCOS log parsing so we can better see framework level errors.
Remove some overly verbose kinesis logs